### PR TITLE
Fix blank pages on protected routes

### DIFF
--- a/src/components/auth/route-components.tsx
+++ b/src/components/auth/route-components.tsx
@@ -4,13 +4,24 @@ import { Navigate } from "react-router-dom";
 import { fine } from "@/lib/fine";
 
 export const ProtectedRoute = ({ Component }: { Component: () => JSX.Element }) => {
-    const { 
-        data: session, 
-        isPending, //loading state
-        error, //error object
+    const {
+        data: session,
+        isPending,
+        error,
     } = fine.auth.useSession()
 
-    if (isPending) return <div></div>;
-    
-    return !session?.user ? <Navigate to='/login' /> : <Component />;
+    if (isPending) {
+        return (
+            <div className="flex h-screen items-center justify-center">
+                Loading...
+            </div>
+        );
+    }
+
+    if (error) {
+        console.error("Session error:", error)
+        return <Navigate to='/login' />
+    }
+
+    return session?.user ? <Component /> : <Navigate to='/login' />;
 };

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -80,7 +80,7 @@ export default function LoginForm() {
               title: "Success",
               description: "You have been signed in successfully.",
             });
-            navigate("/");
+            navigate("/dashboard");
           },
           onError: (ctx) => {
             toast({


### PR DESCRIPTION
## Summary
- handle loading and errors in `ProtectedRoute`
- redirect to `/dashboard` after successful login

## Testing
- `npm run build` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_686421547ad8832cade28ca621aa4c91