### PR TITLE
Fix dashboard blank page

### DIFF
--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -8,12 +8,12 @@ import { motion } from "framer-motion";
 import { Loader2, Users, ClipboardCheck, AlertTriangle, TrendingUp, Calendar } from "lucide-react";
 
 const Dashboard = () => {
-  const { data: session } = fine.auth.useSession();
+  const { data: session, isPending } = fine.auth.useSession();
   const [userRole, setUserRole] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // Prevent rendering if session is undefined (avoid blank page)
-  if (typeof session === "undefined") {
+  // Show a loader while the session is being fetched
+  if (isPending) {
     return (
       <DashboardLayout>
         <div className="flex h-[calc(100vh-4rem)] items-center justify-center">


### PR DESCRIPTION
## Summary
- ensure session loader works by checking `isPending`
- add newline to end of dashboard page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6864316c02e0832c8b61c87006d9daef