### PR TITLE
Fix sidebar role-based navigation

### DIFF
--- a/src/components/layout/AppSidebar.jsx
+++ b/src/components/layout/AppSidebar.jsx
@@ -39,10 +39,11 @@ export function AppSidebar() {
       // For now, we'll simulate getting it from the database
       const getUserRole = async () => {
         try {
-          const users = await fine.table("users")
+          const { data: users } = await fine
+            .table("users")
             .select("role")
             .eq("email", session.user.email);
-          
+
           if (users && users.length > 0) {
             setUserRole(users[0].role);
           }

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -46,10 +46,11 @@ export function Header({ toggleSidebar }) {
       // For now, we'll simulate getting it from the database
       const getUserRole = async () => {
         try {
-          const users = await fine.table("users")
+          const { data: users } = await fine
+            .table("users")
             .select("role")
             .eq("email", session.user.email);
-          
+
           if (users && users.length > 0) {
             setUserRole(users[0].role);
           }

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -23,10 +23,11 @@ const Dashboard = () => {
     const fetchUserRole = async () => {
       if (session?.user) {
         try {
-          const users = await fine.table("users")
+          const { data: users } = await fine
+            .table("users")
             .select("role")
             .eq("email", session.user.email);
-          
+
           if (users && users.length > 0) {
             setUserRole(users[0].role);
           }


### PR DESCRIPTION
## Summary
- fetch data from Fine with destructuring to access rows
- update role fetching logic in sidebar and header
- apply same fix on dashboard page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686466c86b4c832cb548532bfe9fbb7c