### PR TITLE
Remove localStorage and fetch user session from backend

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -28,7 +28,7 @@ import { Badge } from "@/components/ui/badge";
 import { motion } from "framer-motion";
 
 export function Header({ toggleSidebar }) {
-  const { data: session } = fine.auth.useSession();
+  const session = fine.auth.getSessionSync?.() || null;
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
   const [userRole, setUserRole] = useState(null);
@@ -47,13 +47,14 @@ export function Header({ toggleSidebar }) {
       if (!session?.user?.email) return;
 
       try {
-        const users = await fine
-          .table("users")
-          .select("role")
-          .eq("email", session.user.email);
+        const res = await fetch(
+          `http://localhost:3000/api/user/${session.user.email}`
+        );
+        if (!res.ok) throw new Error("Usuario no encontrado");
+        const user = await res.json();
 
-        if (isMounted && users && users.length > 0) {
-          setUserRole(users[0].role);
+        if (isMounted) {
+          setUserRole(user.role);
         }
       } catch (error) {
         console.error("Error fetching user role:", error);

--- a/src/components/layout/theme-provider.jsx
+++ b/src/components/layout/theme-provider.jsx
@@ -2,14 +2,8 @@ import { createContext, useContext, useEffect, useState } from "react";
 
 const ThemeProviderContext = createContext();
 
-export function ThemeProvider({ children, defaultTheme = "system", storageKey = "ui-theme" }) {
-  const [theme, setTheme] = useState(() => {
-    // Check if we're on the client side
-    if (typeof window !== "undefined") {
-      return localStorage.getItem(storageKey) || defaultTheme;
-    }
-    return defaultTheme;
-  });
+export function ThemeProvider({ children, defaultTheme = "system" }) {
+  const [theme, setTheme] = useState(defaultTheme);
 
   useEffect(() => {
     const root = window.document.documentElement;
@@ -31,7 +25,6 @@ export function ThemeProvider({ children, defaultTheme = "system", storageKey = 
   const value = {
     theme,
     setTheme: (newTheme) => {
-      localStorage.setItem(storageKey, newTheme);
       setTheme(newTheme);
     },
   };

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -1,18 +1,11 @@
 import { useState, useEffect } from "react";
+import { fine } from "@/lib/fine";
 
 export function useSession() {
   const [session, setSession] = useState(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem("session");
-    if (stored) {
-      try {
-        setSession(JSON.parse(stored));
-      } catch (error) {
-        console.error("Failed to parse session:", error);
-        setSession(null);
-      }
-    }
+    setSession(fine.auth.getSessionSync?.() || null);
   }, []);
 
   return { session };

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { DashboardLayout } from "@/components/layout/Dashboard";
+import { fine } from "@/lib/fine";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
@@ -7,7 +8,7 @@ import { motion } from "framer-motion";
 import { Loader2, Users, ClipboardCheck, AlertTriangle, TrendingUp, Calendar } from "lucide-react";
 
 const Dashboard = () => {
-  const session = JSON.parse(localStorage.getItem("user") || "{}");
+  const session = fine.auth.getSessionSync?.() || null;
   const [userRole, setUserRole] = useState(null);
   const [loading, setLoading] = useState(true);
   const [stats, setStats] = useState({
@@ -18,10 +19,21 @@ const Dashboard = () => {
     attendanceByDay: []
   });
 
- useEffect(() => {
+useEffect(() => {
   const fetchUserRole = async () => {
-    if (session?.email) {
-      setUserRole(session.role || "teacher");
+    if (!session?.user?.email) return;
+
+    try {
+      const res = await fetch(
+        `http://localhost:3000/api/user/${session.user.email}`
+      );
+      if (!res.ok) throw new Error("Usuario no encontrado");
+
+      const user = await res.json();
+      setUserRole(user.role);
+    } catch (err) {
+      console.error("Error cargando rol:", err);
+      setUserRole("teacher");
     }
   };
 
@@ -90,7 +102,7 @@ const Dashboard = () => {
 
     fetchUserRole();
     fetchDashboardData();
-  }, [session]);
+  }, [session?.user?.email]);
 
   const COLORS = ['#4ade80', '#f87171', '#facc15', '#60a5fa', '#c084fc'];
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
+import { fine } from "@/lib/fine";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -78,10 +79,10 @@ export default function LoginForm() {
 
       toast({ title: "Success", description: "You are now logged in." });
 
-      // Guardar sesión en localStorage
-      localStorage.setItem("user", JSON.stringify(data.user));
+      if (fine?.auth?.setSession) {
+        fine.auth.setSession({ user: data.user });
+      }
 
-      // Redirigir
       navigate("/dashboard", { replace: true });
     } catch (error: any) {
       toast({


### PR DESCRIPTION
## Summary
- remove all localStorage usage in frontend
- fetch user session from backend endpoints
- rely on `fine.auth.getSessionSync` for session data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865dc557c78832c82ce95327a8e2187