### PR TITLE
Fix role-based UI using user context

### DIFF
--- a/src/components/layout/AppSidebar.jsx
+++ b/src/components/layout/AppSidebar.jsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import {
   Sidebar,
@@ -28,41 +27,19 @@ import { useUser } from "@/context/UserContext";
 
 export function AppSidebar() {
   const location = useLocation();
-  const [userRole, setUserRole] = useState(null);
-  const [loading, setLoading] = useState(true);
-
   const { user: session } = useUser();
 
-  useEffect(() => {
-    const getUserRole = async () => {
-      if (!session?.email) return;
-
-      try {
-        const res = await fetch(`http://localhost:3000/api/user/${session.email}`);
-        if (!res.ok) throw new Error("Usuario no encontrado");
-
-        const user = await res.json();
-        setUserRole(user.role);
-      } catch (err) {
-        console.error("Error cargando rol del usuario:", err);
-        setUserRole("teacher"); // fallback
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    getUserRole();
-  }, []);
-
-  if (loading) {
+  if (!session) {
     return (
       <Sidebar className="border-r bg-background">
         <SidebarContent className="p-4 text-muted-foreground text-sm">
-          Cargando menú...
+          Loading menu...
         </SidebarContent>
       </Sidebar>
     );
   }
+
+  const userRole = session.role;
 
   const getMenuItems = () => {
     const baseItems = [

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useUser } from "@/context/UserContext";
 import { Button } from "@/components/ui/button";
@@ -31,7 +31,6 @@ export function Header({ toggleSidebar }) {
   const { user: session } = useUser();
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
-  const [userRole, setUserRole] = useState(null);
   const { theme, setTheme } = useTheme();
   const [notifications, setNotifications] = useState([
     { id: 1, message: "New student added to Grade 3", time: "5 min ago" },
@@ -40,36 +39,7 @@ export function Header({ toggleSidebar }) {
   ]);
   const [showNotifications, setShowNotifications] = useState(false);
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const getUserRole = async () => {
-      if (!session?.email) return;
-
-      try {
-        const res = await fetch(
-          `http://localhost:3000/api/user/${session.email}`
-        );
-        if (!res.ok) throw new Error("Usuario no encontrado");
-        const user = await res.json();
-
-        if (isMounted) {
-          setUserRole(user.role);
-        }
-      } catch (error) {
-        console.error("Error fetching user role:", error);
-        if (isMounted) {
-          setUserRole("teacher");
-        }
-      }
-    };
-
-    getUserRole();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [session?.email]);
+  const userRole = session?.role;
 
   const userInitials = session?.name
     ? session.name
@@ -78,6 +48,14 @@ export function Header({ toggleSidebar }) {
         .join("")
         .toUpperCase()
     : "U";
+
+  if (!session) {
+    return (
+      <header className="sticky top-0 z-30 h-16 border-b bg-background/95 px-4 md:px-6 flex items-center">
+        <span className="text-sm text-muted-foreground">Loading...</span>
+      </header>
+    );
+  }
 
   return (
     <motion.header


### PR DESCRIPTION
## Summary
- update `AppSidebar` to read role from `UserContext`
- update `Header` to show user info and role directly from context
- show loading placeholder while user data loads
- remove unnecessary role fetching logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865fa1d87e8832cbfc09466b7eda13a