### PR TITLE
Fix auth headers and persist user

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,12 +10,20 @@ app.use(express.json());
 
 // Simple authentication middleware using user id header
 export const isAuthenticated = async (req, res, next) => {
-  const userId = req.header('authorization');
-  if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+  const userIdHeader = req.header('authorization');
+  const userId = parseInt(userIdHeader, 10);
+
+  if (!userIdHeader || Number.isNaN(userId)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
   try {
     const [rows] = await db.query('SELECT id FROM users WHERE id = ?', [userId]);
-    if (rows.length === 0) return res.status(401).json({ error: 'Unauthorized' });
-    req.userId = Number(userId);
+    if (rows.length === 0) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    req.userId = userId;
     next();
   } catch (err) {
     console.error(err);

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -15,10 +15,26 @@ interface UserContextValue {
 const UserContext = createContext<UserContextValue | undefined>(undefined);
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
-  const [user, setUserState] = useState<User | null>(null);
+  const [user, setUserState] = useState<User | null>(() => {
+    try {
+      const stored = localStorage.getItem('user');
+      return stored ? (JSON.parse(stored) as User) : null;
+    } catch {
+      return null;
+    }
+  });
 
   const setUser = (u: User | null) => {
     setUserState(u);
+    try {
+      if (u) {
+        localStorage.setItem('user', JSON.stringify(u));
+      } else {
+        localStorage.removeItem('user');
+      }
+    } catch {
+      // ignore storage errors
+    }
   };
 
   return (

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -25,7 +25,10 @@ useEffect(() => {
 
     try {
       const res = await fetch(
-        `http://localhost:3000/api/user/${session.email}`
+        `http://localhost:3000/api/user/${session.email}`,
+        {
+          headers: { Authorization: String(session.id) }
+        }
       );
       if (!res.ok) throw new Error("Usuario no encontrado");
 
@@ -39,6 +42,11 @@ useEffect(() => {
 
     const fetchDashboardData = async () => {
       try {
+        if (session?.id) {
+          await fetch('http://localhost:3000/api/users', {
+            headers: { Authorization: String(session.id) }
+          });
+        }
         // In a real app, you would fetch actual data from the database
         // For now, we'll use mock data
         

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -81,7 +81,7 @@ const LoginForm = () => {
       }
 
       toast({ title: "Success", description: "You are now logged in." });
-      setUser(data.user ?? data);
+      setUser(data.user);
       navigate("/dashboard");
     } catch (error) {
       toast({

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -79,7 +79,7 @@ export default function LoginForm() {
       }
 
       toast({ title: "Success", description: "You are now logged in." });
-      setUser(data.user ?? data);
+      setUser(data.user);
 
       navigate("/dashboard", { replace: true });
     } catch (error: any) {

--- a/src/pages/signup.jsx
+++ b/src/pages/signup.jsx
@@ -78,7 +78,7 @@ export default function SignupForm() {
       }
 
       toast({ title: "Account created", description: "Welcome!" });
-      setUser(data.user ?? data);
+      setUser(data.user);
       navigate("/dashboard");
     } catch (error) {
       toast({

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -80,7 +80,7 @@ export default function SignupForm() {
       }
 
       toast({ title: "Account created", description: "Welcome!" });
-      setUser(data.user ?? data);
+      setUser(data.user);
       navigate("/dashboard");
     } catch (error: any) {
       toast({


### PR DESCRIPTION
## Summary
- ensure user id header is parsed correctly in backend middleware
- persist logged user to localStorage in `UserContext`
- store returned user after login/signup
- include Authorization header when dashboard fetches protected data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686604083040832cb4bb7b1d455a0aef