### PR TITLE
Add student role support

### DIFF
--- a/fine/server.js
+++ b/fine/server.js
@@ -27,6 +27,11 @@ app.post('/api/signup', async (req, res) => {
     return res.status(400).json({ error: 'Faltan campos' });
   }
 
+  const allowedRoles = ['teacher', 'student', 'admin'];
+  if (!allowedRoles.includes(role)) {
+    return res.status(400).json({ error: 'Rol inválido' });
+  }
+
   try {
     const [exists] = await db.query('SELECT id FROM users WHERE email = ?', [email]);
     if (exists.length > 0) {

--- a/server.js
+++ b/server.js
@@ -52,9 +52,13 @@ app.post('/api/login', async (req, res) => {
 });
 
 app.post('/api/signup', async (req, res) => {
-  const { name, email, password } = req.body;
-  if (!name || !email || !password) {
+  const { name, email, password, role } = req.body;
+  if (!name || !email || !password || !role) {
     return res.status(400).json({ error: 'Faltan campos' });
+  }
+  const allowedRoles = ['teacher', 'student', 'admin'];
+  if (!allowedRoles.includes(role)) {
+    return res.status(400).json({ error: 'Rol inválido' });
   }
   try {
     const [exists] = await db.query('SELECT id FROM users WHERE email = ?', [email]);
@@ -63,9 +67,9 @@ app.post('/api/signup', async (req, res) => {
     }
     const [result] = await db.query(
       'INSERT INTO users (name, email, password, role) VALUES (?, ?, ?, ?)',
-      [name, email, password, 'teacher']
+      [name, email, password, role]
     );
-    const user = { id: result.insertId, name, email, role: 'teacher' };
+    const user = { id: result.insertId, name, email, role };
     res.status(201).json({ user });
   } catch (err) {
     console.error(err);

--- a/src/components/auth/route-components.jsx
+++ b/src/components/auth/route-components.jsx
@@ -1,10 +1,13 @@
 import { Navigate } from "react-router-dom";
 import { useUser } from "@/context/UserContext";
 
-export const ProtectedRoute = ({ Component }) => {
+export const ProtectedRoute = ({ Component, roles }) => {
     const { user } = useUser();
 
     if (!user) return <Navigate to='/login' />;
+    if (roles && !roles.includes(user.role)) {
+        return <Navigate to={user.role === 'student' ? '/student-dashboard' : '/dashboard'} replace />;
+    }
 
     return <Component />;
 };

--- a/src/components/auth/route-components.tsx
+++ b/src/components/auth/route-components.tsx
@@ -3,8 +3,18 @@
 import { Navigate } from "react-router-dom";
 import { useUser } from "@/context/UserContext";
 
-export const ProtectedRoute = ({ Component }: { Component: () => JSX.Element }) => {
-    const { user } = useUser();
+interface ProtectedProps {
+  Component: () => JSX.Element;
+  roles?: string[];
+}
 
-    return !user ? <Navigate to='/login' /> : <Component />;
+export const ProtectedRoute = ({ Component, roles }: ProtectedProps) => {
+  const { user } = useUser();
+
+  if (!user) return <Navigate to='/login' />;
+  if (roles && !roles.includes(user.role)) {
+    // Redirect to a default dashboard based on role
+    return <Navigate to={user.role === 'student' ? '/student-dashboard' : '/dashboard'} replace />;
+  }
+  return <Component />;
 };

--- a/src/components/layout/AppSidebar.jsx
+++ b/src/components/layout/AppSidebar.jsx
@@ -43,7 +43,7 @@ export function AppSidebar() {
 
   const getMenuItems = () => {
     const baseItems = [
-      { title: "Dashboard", url: "/dashboard", icon: Home },
+      { title: "Dashboard", url: userRole === "student" ? "/student-dashboard" : "/dashboard", icon: Home },
     ];
 
     const adminItems = [
@@ -136,21 +136,23 @@ export function AppSidebar() {
           <div className="rounded-lg bg-primary/10 p-4">
             <div className="flex items-center gap-2 mb-2">
               <div className="h-8 w-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-xs font-bold">
-                {userRole === "admin" ? "A" : "T"}
+                {userRole === "admin" ? "A" : userRole === "teacher" ? "T" : "S"}
               </div>
               <div>
                 <p className="text-sm font-medium">
-                  {userRole === "admin" ? "Admin" : "Teacher"} Mode
+                  {userRole === "admin" ? "Admin" : userRole === "teacher" ? "Teacher" : "Student"} Mode
                 </p>
                 <p className="text-xs text-muted-foreground">
-                  {userRole === "admin" ? "Full access" : "Limited access"}
+                  {userRole === "admin" ? "Full access" : userRole === "teacher" ? "Limited access" : "Student view"}
                 </p>
               </div>
             </div>
             <div className="text-xs text-muted-foreground">
               {userRole === "admin"
                 ? "You have full administrative privileges"
-                : "You can manage grades and students"}
+                : userRole === "teacher"
+                ? "You can manage grades and students"
+                : "View your attendance and reports"}
             </div>
           </div>
         </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,6 +13,7 @@ import LoginForm from "./pages/login";
 import SignupForm from "./pages/signup";
 import Logout from "./pages/logout";
 import Dashboard from "./pages/dashboard";
+import StudentDashboard from "./pages/student-dashboard";
 import PasswordRecovery from "./pages/password-recovery";
 import Profile from "./pages/profile";
 
@@ -48,21 +49,22 @@ createRoot(document.getElementById("root")).render(
             <Route path="/password-recovery" element={<PasswordRecovery />} />
             
             {/* Protected Routes */}
-            <Route path="/dashboard" element={<ProtectedRoute Component={Dashboard} />} />
+            <Route path="/dashboard" element={<ProtectedRoute Component={Dashboard} roles={["teacher", "admin"]} />} />
+            <Route path="/student-dashboard" element={<ProtectedRoute Component={StudentDashboard} roles={["student"]} />} />
             <Route path="/profile" element={<ProtectedRoute Component={Profile} />} />
             
             {/* Admin Routes */}
-            <Route path="/admin/teachers" element={<ProtectedRoute Component={AdminTeachers} />} />
-            <Route path="/admin/levels" element={<ProtectedRoute Component={AdminLevels} />} />
-            <Route path="/admin/projections" element={<ProtectedRoute Component={AdminProjections} />} />
-            <Route path="/admin/settings" element={<ProtectedRoute Component={AdminSettings} />} />
+            <Route path="/admin/teachers" element={<ProtectedRoute Component={AdminTeachers} roles={["admin"]} />} />
+            <Route path="/admin/levels" element={<ProtectedRoute Component={AdminLevels} roles={["admin"]} />} />
+            <Route path="/admin/projections" element={<ProtectedRoute Component={AdminProjections} roles={["admin"]} />} />
+            <Route path="/admin/settings" element={<ProtectedRoute Component={AdminSettings} roles={["admin"]} />} />
             
             {/* Teacher Routes */}
-            <Route path="/teacher/grades" element={<ProtectedRoute Component={TeacherGrades} />} />
-            <Route path="/teacher/students" element={<ProtectedRoute Component={TeacherStudents} />} />
-            <Route path="/teacher/attendance" element={<ProtectedRoute Component={TeacherAttendance} />} />
-            <Route path="/teacher/reports" element={<ProtectedRoute Component={TeacherReports} />} />
-            <Route path="/teacher/projections" element={<ProtectedRoute Component={TeacherProjections} />} />
+            <Route path="/teacher/grades" element={<ProtectedRoute Component={TeacherGrades} roles={["teacher"]} />} />
+            <Route path="/teacher/students" element={<ProtectedRoute Component={TeacherStudents} roles={["teacher"]} />} />
+            <Route path="/teacher/attendance" element={<ProtectedRoute Component={TeacherAttendance} roles={["teacher"]} />} />
+            <Route path="/teacher/reports" element={<ProtectedRoute Component={TeacherReports} roles={["teacher"]} />} />
+            <Route path="/teacher/projections" element={<ProtectedRoute Component={TeacherProjections} roles={["teacher"]} />} />
           </Routes>
         </BrowserRouter>
         <Sonner />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import LoginForm from "./pages/login";
 import SignupForm from "./pages/signup";
 import Logout from "./pages/logout";
 import Dashboard from "./pages/dashboard";
+import StudentDashboard from "./pages/student-dashboard";
 import Profile from "./pages/profile";
 import PasswordRecovery from "./pages/password-recovery";
 
@@ -53,21 +54,22 @@ createRoot(document.getElementById("root")!).render(
               <Route path="/password-recovery" element={<PasswordRecovery />} />
 
               {/* Protected Routes */}
-              <Route path="/dashboard" element={<ProtectedRoute Component={Dashboard} />} />
+              <Route path="/dashboard" element={<ProtectedRoute Component={Dashboard} roles={["teacher", "admin"]} />} />
+              <Route path="/student-dashboard" element={<ProtectedRoute Component={StudentDashboard} roles={["student"]} />} />
               <Route path="/profile" element={<ProtectedRoute Component={Profile} />} />
 
               {/* Admin Routes */}
-              <Route path="/admin/teachers" element={<ProtectedRoute Component={AdminTeachers} />} />
-              <Route path="/admin/levels" element={<ProtectedRoute Component={AdminLevels} />} />
-              <Route path="/admin/projections" element={<ProtectedRoute Component={AdminProjections} />} />
-              <Route path="/admin/settings" element={<ProtectedRoute Component={AdminSettings} />} />
+              <Route path="/admin/teachers" element={<ProtectedRoute Component={AdminTeachers} roles={["admin"]} />} />
+              <Route path="/admin/levels" element={<ProtectedRoute Component={AdminLevels} roles={["admin"]} />} />
+              <Route path="/admin/projections" element={<ProtectedRoute Component={AdminProjections} roles={["admin"]} />} />
+              <Route path="/admin/settings" element={<ProtectedRoute Component={AdminSettings} roles={["admin"]} />} />
 
               {/* Teacher Routes */}
-              <Route path="/teacher/grades" element={<ProtectedRoute Component={TeacherGrades} />} />
-              <Route path="/teacher/students" element={<ProtectedRoute Component={TeacherStudents} />} />
-              <Route path="/teacher/attendance" element={<ProtectedRoute Component={TeacherAttendance} />} />
-              <Route path="/teacher/reports" element={<ProtectedRoute Component={TeacherReports} />} />
-              <Route path="/teacher/projections" element={<ProtectedRoute Component={TeacherProjections} />} />
+              <Route path="/teacher/grades" element={<ProtectedRoute Component={TeacherGrades} roles={["teacher"]} />} />
+              <Route path="/teacher/students" element={<ProtectedRoute Component={TeacherStudents} roles={["teacher"]} />} />
+              <Route path="/teacher/attendance" element={<ProtectedRoute Component={TeacherAttendance} roles={["teacher"]} />} />
+              <Route path="/teacher/reports" element={<ProtectedRoute Component={TeacherReports} roles={["teacher"]} />} />
+              <Route path="/teacher/projections" element={<ProtectedRoute Component={TeacherProjections} roles={["teacher"]} />} />
             </Routes>
           </BrowserRouter>
           <Sonner />

--- a/src/pages/login.jsx
+++ b/src/pages/login.jsx
@@ -82,7 +82,11 @@ const LoginForm = () => {
 
       toast({ title: "Success", description: "You are now logged in." });
       setUser(data.user);
-      navigate("/dashboard");
+      if (data.user.role === "student") {
+        navigate("/student-dashboard");
+      } else {
+        navigate("/dashboard");
+      }
     } catch (error) {
       toast({
         title: "Error",

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -81,7 +81,11 @@ export default function LoginForm() {
       toast({ title: "Success", description: "You are now logged in." });
       setUser(data.user);
 
-      navigate("/dashboard", { replace: true });
+      if (data.user.role === "student") {
+        navigate("/student-dashboard", { replace: true });
+      } else {
+        navigate("/dashboard", { replace: true });
+      }
     } catch (error: any) {
       toast({
         title: "Error",

--- a/src/pages/signup.jsx
+++ b/src/pages/signup.jsx
@@ -82,7 +82,11 @@ export default function SignupForm() {
 
       toast({ title: "Account created", description: "Welcome!" });
       setUser(data.user);
-      navigate("/dashboard");
+      if (data.user.role === "student") {
+        navigate("/student-dashboard");
+      } else {
+        navigate("/dashboard");
+      }
     } catch (error) {
       toast({
         title: "Error",
@@ -157,7 +161,7 @@ export default function SignupForm() {
                 className='w-full rounded border px-3 py-2'
               >
                 <option value='teacher'>Teacher</option>
-                <option value='admin'>Admin</option>
+                <option value='student'>Student</option>
               </select>
               {errors.role && <p className='text-sm text-destructive'>{errors.role}</p>}
             </div>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -16,13 +16,16 @@ export default function SignupForm() {
     email: "",
     password: "",
     name: "",
+    role: "teacher",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
   const navigate = useNavigate();
   const { toast } = useToast();
   const { setUser } = useUser();
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
 
@@ -55,6 +58,10 @@ export default function SignupForm() {
       newErrors.name = "Name is required";
     }
 
+    if (!formData.role) {
+      newErrors.role = "Role is required";
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -81,7 +88,11 @@ export default function SignupForm() {
 
       toast({ title: "Account created", description: "Welcome!" });
       setUser(data.user);
-      navigate("/dashboard");
+      if (data.user.role === "student") {
+        navigate("/student-dashboard");
+      } else {
+        navigate("/dashboard");
+      }
     } catch (error: any) {
       toast({
         title: "Error",
@@ -143,6 +154,22 @@ export default function SignupForm() {
                 aria-invalid={!!errors.password}
               />
               {errors.password && <p className='text-sm text-destructive'>{errors.password}</p>}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='role'>Role</Label>
+              <select
+                id='role'
+                name='role'
+                value={formData.role}
+                onChange={handleChange}
+                disabled={isLoading}
+                className='w-full rounded border px-3 py-2'
+              >
+                <option value='teacher'>Teacher</option>
+                <option value='student'>Student</option>
+              </select>
+              {errors.role && <p className='text-sm text-destructive'>{errors.role}</p>}
             </div>
           </CardContent>
 

--- a/src/pages/student-dashboard.jsx
+++ b/src/pages/student-dashboard.jsx
@@ -1,0 +1,16 @@
+import { DashboardLayout } from "@/components/layout/Dashboard";
+import { useUser } from "@/context/UserContext";
+
+const StudentDashboard = () => {
+  const { user } = useUser();
+  return (
+    <DashboardLayout>
+      <div className="p-6 space-y-2">
+        <h1 className="text-3xl font-bold">Student Dashboard</h1>
+        <p className="text-muted-foreground">Welcome back, {user?.name}!</p>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default StudentDashboard;

--- a/src/pages/student-dashboard.tsx
+++ b/src/pages/student-dashboard.tsx
@@ -1,0 +1,16 @@
+import { DashboardLayout } from "@/components/layout/Dashboard";
+import { useUser } from "@/context/UserContext";
+
+const StudentDashboard = () => {
+  const { user } = useUser();
+  return (
+    <DashboardLayout>
+      <div className="p-6 space-y-2">
+        <h1 className="text-3xl font-bold">Student Dashboard</h1>
+        <p className="text-muted-foreground">Welcome back, {user?.name}!</p>
+      </div>
+    </DashboardLayout>
+  );
+};
+
+export default StudentDashboard;


### PR DESCRIPTION
## Summary
- allow choosing role on signup form and pass it to backend
- redirect login/signup based on role
- validate role on express signup route
- add simple student dashboard page
- show role aware sidebar
- add role-based route protection

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68660bf12fb0832cbef8568e5588811a