### PR TITLE
Add recovery word field to signup

### DIFF
--- a/src/pages/signup.jsx
+++ b/src/pages/signup.jsx
@@ -16,6 +16,7 @@ export default function SignupForm() {
     email: "",
     password: "",
     name: "",
+    recoveryWord: "",
     role: "teacher", // default
   });
   const [errors, setErrors] = useState({});
@@ -53,6 +54,10 @@ export default function SignupForm() {
 
     if (!formData.name) {
       newErrors.name = "Name is required";
+    }
+
+    if (!formData.recoveryWord) {
+      newErrors.recoveryWord = "Recovery word is required";
     }
 
     if (!formData.role) {
@@ -148,6 +153,22 @@ export default function SignupForm() {
                 aria-invalid={!!errors.password}
               />
               {errors.password && <p className='text-sm text-destructive'>{errors.password}</p>}
+            </div>
+
+            <div className='space-y-2'>
+              <Label htmlFor='recoveryWord'>Recovery word</Label>
+              <Input
+                id='recoveryWord'
+                name='recoveryWord'
+                placeholder='Something only you know'
+                value={formData.recoveryWord}
+                onChange={handleChange}
+                disabled={isLoading}
+                aria-invalid={!!errors.recoveryWord}
+              />
+              {errors.recoveryWord && (
+                <p className='text-sm text-destructive'>{errors.recoveryWord}</p>
+              )}
             </div>
 
             <div className='space-y-2'>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -166,7 +166,7 @@ export default function SignupForm() {
               <Input
                 id='recoveryWord'
                 name='recoveryWord'
-                placeholder='Your secret word'
+                placeholder='Something only you know'
                 value={formData.recoveryWord}
                 onChange={handleChange}
                 disabled={isLoading}


### PR DESCRIPTION
## Summary
- add `recoveryWord` to form data state in the JS version of the signup page
- validate `recoveryWord` in JS signup page
- render a new Recovery word input between password and role on both TSX and JSX pages
- update placeholder to `Something only you know`

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_686804de817c832cb3dec2e10e1146e3