### PR TITLE
Switch some pages to use API calls

### DIFF
--- a/src/pages/admin/teachers.jsx
+++ b/src/pages/admin/teachers.jsx
@@ -10,6 +10,8 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { useToast } from "@/hooks/use-toast";
 import { Loader2, Plus, Trash2, UserPlus } from "lucide-react";
 
+const API_BASE_URL = "http://localhost:3000/api";
+
 const AdminTeachers = () => {
   const [teachers, setTeachers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -25,16 +27,11 @@ const AdminTeachers = () => {
   useEffect(() => {
     const fetchTeachers = async () => {
       try {
+        const res = await fetch(`${API_BASE_URL}/teachers`);
+        if (!res.ok) throw new Error("Failed to fetch teachers");
+        const data = await res.json();
 
-        const mockTeachers = [
-          { id: 1, name: "John Doe", email: "john.doe@school.com", createdAt: "2023-01-15" },
-          { id: 2, name: "Jane Smith", email: "jane.smith@school.com", createdAt: "2023-02-20" },
-          { id: 3, name: "Robert Johnson", email: "robert.johnson@school.com", createdAt: "2023-03-10" },
-          { id: 4, name: "Emily Davis", email: "emily.davis@school.com", createdAt: "2023-04-05" },
-          { id: 5, name: "Michael Wilson", email: "michael.wilson@school.com", createdAt: "2023-05-12" },
-        ];
-        
-        setTeachers(mockTeachers);
+        setTeachers(data);
       } catch (error) {
         console.error("Error fetching teachers:", error);
         toast({
@@ -70,17 +67,17 @@ const AdminTeachers = () => {
     setIsAddingTeacher(true);
     
     try {
+      const res = await fetch(`${API_BASE_URL}/teachers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newTeacher),
+      });
 
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      const newTeacherId = teachers.length + 1;
-      const newTeacherWithId = {
-        id: newTeacherId,
-        ...newTeacher,
-        createdAt: new Date().toISOString().split("T")[0],
-      };
-      
-      setTeachers((prev) => [...prev, newTeacherWithId]);
+      if (!res.ok) throw new Error("Failed to add teacher");
+
+      const created = await res.json();
+
+      setTeachers((prev) => [...prev, created]);
       
       setNewTeacher({
         name: "",
@@ -107,9 +104,12 @@ const AdminTeachers = () => {
 
   const handleDeleteTeacher = async (teacherId) => {
     try {
+      const res = await fetch(`${API_BASE_URL}/teachers/${teacherId}`, {
+        method: "DELETE",
+      });
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      if (!res.ok) throw new Error("Failed to delete teacher");
+
       setTeachers((prev) => prev.filter((teacher) => teacher.id !== teacherId));
       
       toast({

--- a/src/pages/teacher/attendance.jsx
+++ b/src/pages/teacher/attendance.jsx
@@ -12,6 +12,8 @@ import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { motion } from "framer-motion";
+
+const API_BASE_URL = "http://localhost:3000/api";
 import { 
   Loader2, ArrowLeft, Check, X, Mail, Clock, Save, 
   AlertTriangle, CheckCircle2, XCircle, AlertCircle, 
@@ -47,73 +49,16 @@ const TeacherAttendance = () => {
       if (!gradeId) return;
       
       try {
+        const gradeRes = await fetch(`${API_BASE_URL}/grades/${gradeId}`);
+        if (!gradeRes.ok) throw new Error("Failed to fetch grade");
+        const gradeData = await gradeRes.json();
 
-        
-        // Mock grade
-        const mockGrade = { id: parseInt(gradeId), name: `Grade ${gradeId}` };
-        
-        // Mock students for this grade with attendance status
-        const mockStudents = [
-          { 
-            id: 1, 
-            name: "Alice Johnson", 
-            email: "alice@example.com", 
-            status: "present",
-            uniform: { shoes: true, shirt: true, pants: true, sweater: true, haircut: true }
-          },
-          { 
-            id: 2, 
-            name: "Bob Smith", 
-            email: "bob@example.com", 
-            status: "present",
-            uniform: { shoes: true, shirt: true, pants: true, sweater: false, haircut: true }
-          },
-          { 
-            id: 3, 
-            name: "Charlie Brown", 
-            email: "charlie@example.com", 
-            status: "absent",
-            uniform: { shoes: true, shirt: true, pants: true, sweater: true, haircut: true }
-          },
-          { 
-            id: 4, 
-            name: "Diana Prince", 
-            email: "diana@example.com", 
-            status: "late",
-            uniform: { shoes: false, shirt: true, pants: true, sweater: true, haircut: true }
-          },
-          { 
-            id: 5, 
-            name: "Edward Cullen", 
-            email: "edward@example.com", 
-            status: "present",
-            uniform: { shoes: true, shirt: false, pants: true, sweater: true, haircut: false }
-          },
-          { 
-            id: 6, 
-            name: "Fiona Gallagher", 
-            email: "fiona@example.com", 
-            status: "present",
-            uniform: { shoes: true, shirt: true, pants: true, sweater: true, haircut: true }
-          },
-          { 
-            id: 7, 
-            name: "George Washington", 
-            email: "george@example.com", 
-            status: "absent",
-            uniform: { shoes: true, shirt: true, pants: false, sweater: true, haircut: true }
-          },
-          { 
-            id: 8, 
-            name: "Hannah Montana", 
-            email: "hannah@example.com", 
-            status: "late",
-            uniform: { shoes: true, shirt: true, pants: true, sweater: false, haircut: true }
-          },
-        ];
-        
-        setGrade(mockGrade);
-        setStudents(mockStudents);
+        const studentsRes = await fetch(`${API_BASE_URL}/students?gradeId=${gradeId}`);
+        if (!studentsRes.ok) throw new Error("Failed to fetch students");
+        const studentsData = await studentsRes.json();
+
+        setGrade(gradeData);
+        setStudents(studentsData);
         
         // Check if attendance has been recorded for today
         setAttendanceRecorded(false); 
@@ -180,11 +125,20 @@ const TeacherAttendance = () => {
 
   const saveAttendance = async () => {
     setSaving(true);
-    
-    try {
 
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
+    try {
+      const res = await fetch(`${API_BASE_URL}/attendance`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          gradeId: parseInt(gradeId),
+          date: attendanceDate,
+          students,
+        }),
+      });
+
+      if (!res.ok) throw new Error("Failed to save attendance");
+
       setAttendanceRecorded(true);
       
       toast({
@@ -209,11 +163,19 @@ const TeacherAttendance = () => {
 
   const sendEmail = async (type) => {
     try {
+      const res = await fetch(`${API_BASE_URL}/emails`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          studentId: selectedStudent.id,
+          type,
+        }),
+      });
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      if (!res.ok) throw new Error("Failed to send email");
+
       setEmailDialogOpen(false);
-      
+
       toast({
         title: "Email Sent",
         description: `Email sent to ${selectedStudent.name} successfully.`,


### PR DESCRIPTION
## Summary
- remove mock data in teacher/student management, admin teachers and attendance pages
- call backend using `fetch` for loading data and CRUD actions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bf4e3d1fc832c96ea3547a8097caa