### PR TITLE
Add teachers API route

### DIFF
--- a/routes/teachers.js
+++ b/routes/teachers.js
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { db } from '../fine/db.js';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  try {
+    const [rows] = await db.query(
+      "SELECT id, name, email FROM users WHERE role = 'teacher'"
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
+});
+
+export default router;

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from './fine/db.js';
+import teacherRoutes from './routes/teachers.js';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -9,6 +10,7 @@ const IS_DEV = process.env.NODE_ENV !== 'production';
 
 app.use(cors());
 app.use(express.json());
+app.use('/api/teachers', teacherRoutes);
 
 // Simple in-memory store for recovery tokens
 const recoveryTokens = new Map();


### PR DESCRIPTION
## Summary
- add teachers router to query teachers from users table
- mount router in main server

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bf9b39038832c993bbea8e8b5a844