### PR TITLE
Implement backend endpoints for levels and grades

### DIFF
--- a/routes/grades.js
+++ b/routes/grades.js
@@ -8,7 +8,8 @@ const router = express.Router();
 router.get("/", async (_req, res) => {
   try {
     const [rows] = await db.query(
-      `SELECT grades.id, grades.name, levels.name AS level, users.name AS teacher
+      `SELECT grades.id, grades.name, grades.levelId, grades.teacherId,
+              levels.name AS levelName, users.name AS teacherName
        FROM grades
        JOIN levels ON grades.levelId = levels.id
        LEFT JOIN users ON grades.teacherId = users.id`
@@ -16,6 +17,27 @@ router.get("/", async (_req, res) => {
     res.json(rows);
   } catch (err) {
     console.error("Error al obtener grados:", err);
+    res.status(500).json({ error: "Error interno del servidor" });
+  }
+});
+
+// Obtener grado por id
+router.get("/:id", async (req, res) => {
+  const { id } = req.params;
+  try {
+    const [rows] = await db.query(
+      `SELECT grades.id, grades.name, grades.levelId, grades.teacherId,
+              levels.name AS levelName, users.name AS teacherName
+       FROM grades
+       JOIN levels ON grades.levelId = levels.id
+       LEFT JOIN users ON grades.teacherId = users.id
+       WHERE grades.id = ?`,
+      [id]
+    );
+    if (rows.length === 0) return res.status(404).json({ error: "No encontrado" });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error("Error al obtener grado:", err);
     res.status(500).json({ error: "Error interno del servidor" });
   }
 });

--- a/routes/levels.js
+++ b/routes/levels.js
@@ -14,4 +14,22 @@ router.get('/', async (_req, res) => {
   }
 });
 
+// Crear nuevo nivel
+router.post('/', async (req, res) => {
+  const { name, description } = req.body;
+  if (!name) {
+    return res.status(400).json({ error: 'Faltan campos' });
+  }
+  try {
+    const [result] = await db.query(
+      'INSERT INTO levels (name, description) VALUES (?, ?)',
+      [name, description || null]
+    );
+    res.status(201).json({ id: result.insertId, name, description });
+  } catch (err) {
+    console.error('Error al crear nivel:', err);
+    res.status(500).json({ error: 'Error interno del servidor' });
+  }
+});
+
 export default router;

--- a/routes/students.js
+++ b/routes/students.js
@@ -5,13 +5,18 @@ import { db } from "../fine/db.js";
 const router = express.Router();
 
 // Obtener todos los estudiantes
-router.get("/", async (_req, res) => {
+router.get("/", async (req, res) => {
   try {
-    const [rows] = await db.query(
-      `SELECT students.id, students.name, students.email, grades.name AS grade
+    let query =
+      `SELECT students.id, students.name, students.email, students.gradeId, grades.name AS grade
        FROM students
-       JOIN grades ON students.gradeId = grades.id`
-    );
+       JOIN grades ON students.gradeId = grades.id`;
+    const params = [];
+    if (req.query.gradeId) {
+      query += " WHERE students.gradeId = ?";
+      params.push(req.query.gradeId);
+    }
+    const [rows] = await db.query(query, params);
     res.json(rows);
   } catch (err) {
     console.error("Error al obtener estudiantes:", err);


### PR DESCRIPTION
## Summary
- add POST /api/levels endpoint
- extend grades endpoints with more data and new GET /api/grades/:id
- filter students by gradeId query param

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c360e26a8832c839edd7b3153e99b