### PR TITLE
Switch to HashRouter for GitHub Pages

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { Toaster } from "@/components/ui/toaster";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { HashRouter, Route, Routes } from "react-router-dom";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { ThemeProvider } from "./components/layout/theme-provider";
 import { UserProvider } from "@/context/UserContext"; 
@@ -40,7 +40,7 @@ createRoot(document.getElementById("root")).render(
     <TooltipProvider>
       <ThemeProvider defaultTheme="light">
         <UserProvider> {/* ✅ ENVUELVE TODO AQUÍ */}
-          <BrowserRouter basename={import.meta.env.BASE_URL}>
+          <HashRouter basename={import.meta.env.BASE_URL}>
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/login" element={<LoginForm />} />
@@ -59,7 +59,7 @@ createRoot(document.getElementById("root")).render(
               <Route path="/teacher/reports" element={<ProtectedRoute Component={TeacherReports} roles={["teacher", "admin"]} />} />
               <Route path="/teacher/projections" element={<ProtectedRoute Component={TeacherProjections} roles={["teacher", "admin"]} />} />
             </Routes>
-          </BrowserRouter>
+          </HashRouter>
           <Sonner />
           <Toaster />
         </UserProvider>


### PR DESCRIPTION
## Summary
- use `HashRouter` instead of `BrowserRouter` so refreshes work on GitHub Pages

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_687422c23900832c92b60f060d8f7320