### PR TITLE
Fix teacher query with Supabase hook

### DIFF
--- a/src/hooks/use-teachers.js
+++ b/src/hooks/use-teachers.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { supabase } from "../../supabaseClient";
+
+export default function useTeachers() {
+  const [teachers, setTeachers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchTeachers = async () => {
+      const { data, error } = await supabase
+        .from("users")
+        .select("*")
+        .eq("role", "teacher");
+      if (!error) setTeachers(data || []);
+      setLoading(false);
+    };
+    fetchTeachers();
+  }, []);
+
+  return { teachers, loading, setTeachers };
+}

--- a/src/pages/admin/teachers.jsx
+++ b/src/pages/admin/teachers.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { DashboardLayout } from "@/components/layout/Dashboard";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,36 +21,15 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { Loader2, Plus, Trash2, UserPlus } from "lucide-react";
 import { supabase } from "../../../supabaseClient";
+import useTeachers from "@/hooks/use-teachers";
 
 const AdminTeachers = () => {
-  const [teachers, setTeachers] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const { teachers, loading, setTeachers } = useTeachers();
   const [newTeacher, setNewTeacher] = useState({ name: "", email: "", password: "" });
   const [isAddingTeacher, setIsAddingTeacher] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
 
-  useEffect(() => {
-    const fetchTeachers = async () => {
-      try {
-        const { data, error } = await supabase
-          .from("teachers")
-          .select("id, name, email, created_at");
-        if (error) throw error;
-        setTeachers(data);
-      } catch (error) {
-        toast({
-          title: "Error",
-          description: "Failed to load teachers. Please try again.",
-          variant: "destructive",
-        });
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchTeachers();
-  }, [toast]);
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;


### PR DESCRIPTION
## Summary
- add `useTeachers` hook that queries teachers from Supabase using `.eq('role', 'teacher')`
- refactor AdminTeachers page to use the new hook and remove incorrect request logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6875e42e0d90832cb1ff3ba32726d6b2