### PR TITLE
Add hook to fetch teachers with grades

### DIFF
--- a/src/components/TeacherList.jsx
+++ b/src/components/TeacherList.jsx
@@ -1,0 +1,25 @@
+import useTeachersWithGrades from "@/hooks/use-teachers-with-grades";
+
+export default function TeacherList() {
+  const { data, loading, error } = useTeachersWithGrades();
+
+  if (loading) return <p>Cargando...</p>;
+  if (error) return <p>{error}</p>;
+  if (!data || data.length === 0) return <p>No hay datos.</p>;
+
+  return (
+    <ul>
+      {data.map((teacher) => (
+        <li key={teacher.id} className="mb-4">
+          <p className="font-semibold">{teacher.name}</p>
+          <ul className="ml-4 list-disc">
+            {teacher.grades.map((g) => (
+              <li key={g.id}>{g.name}</li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/hooks/use-teachers-with-grades.js
+++ b/src/hooks/use-teachers-with-grades.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export default function useTeachersWithGrades() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/teachers-with-grades');
+        if (!res.ok) throw new Error('Failed to fetch');
+        const json = await res.json();
+        setData(json);
+        setError(null);
+      } catch (err) {
+        setError(err.message || 'Error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return { data, loading, error };
+}
+


### PR DESCRIPTION
## Summary
- add `useTeachersWithGrades` hook for API fetch
- show a list of teachers and their grades in `TeacherList` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_687720339c30832ca93b21e565a92a31