### PR TITLE
Implement teachers with grades hook

### DIFF
--- a/src/components/TeachersGrades.jsx
+++ b/src/components/TeachersGrades.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import useTeachersWithGrades from "@/hooks/use-teachers-with-grades";
+import { supabase } from "../../supabaseClient";
+
+export default function TeachersGrades() {
+  const { data, loading, error } = useTeachersWithGrades();
+  const [levels, setLevels] = useState([]);
+  const [selected, setSelected] = useState("all");
+
+  useEffect(() => {
+    const fetchLevels = async () => {
+      const { data: lvls } = await supabase
+        .from("levels")
+        .select("id, name");
+      setLevels(lvls || []);
+    };
+    fetchLevels();
+  }, []);
+
+  const filtered =
+    selected === "all"
+      ? data
+      : (data || []).filter((t) =>
+          t.grades.some((g) => String(g.levelId) === String(selected))
+        );
+
+  if (loading) return <p>Cargando...</p>;
+  if (error) return <p>{error}</p>;
+  if (!filtered || filtered.length === 0) return <p>No hay datos.</p>;
+
+  return (
+    <div>
+      {levels.length > 0 && (
+        <select
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
+          className="mb-4 border px-2 py-1"
+        >
+          <option value="all">Todos los niveles</option>
+          {levels.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+      )}
+      <ul>
+        {filtered.map((teacher) => (
+          <li key={teacher.id} className="mb-4">
+            <p className="font-semibold">
+              {teacher.name} ({teacher.email})
+            </p>
+            <ul className="ml-4 list-disc">
+              {teacher.grades.map((g) => (
+                <li key={g.id}>{g.name}</li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/hooks/use-teachers-with-grades.js
+++ b/src/hooks/use-teachers-with-grades.js
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
+import { supabase } from "../../supabaseClient";
 
 export default function useTeachersWithGrades() {
-  const [data, setData] = useState(null);
+  const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -9,9 +10,36 @@ export default function useTeachersWithGrades() {
     const fetchData = async () => {
       try {
         const res = await fetch('/api/teachers-with-grades');
-        if (!res.ok) throw new Error('Failed to fetch');
-        const json = await res.json();
-        setData(json);
+        if (res.ok) {
+          const json = await res.json();
+          setData(json);
+          setError(null);
+          return;
+        }
+      } catch (_) {
+        // Ignored - fallback to Supabase
+      }
+
+      try {
+        const { data: grades, error: supaErr } = await supabase
+          .from('grades')
+          .select('id, name, teacherId, levelId, teacher:users(id, name, email)');
+        if (supaErr) throw supaErr;
+
+        const grouped = {};
+        for (const g of grades || []) {
+          if (!g.teacher) continue;
+          if (!grouped[g.teacher.id]) {
+            grouped[g.teacher.id] = {
+              id: g.teacher.id,
+              name: g.teacher.name,
+              email: g.teacher.email,
+              grades: [],
+            };
+          }
+          grouped[g.teacher.id].grades.push({ id: g.id, name: g.name, teacherId: g.teacherId, levelId: g.levelId });
+        }
+        setData(Object.values(grouped));
         setError(null);
       } catch (err) {
         setError(err.message || 'Error');


### PR DESCRIPTION
## Summary
- improve `use-teachers-with-grades` with Supabase fallback and data grouping
- add `TeachersGrades` component that lists teachers and their grades

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877294820c0832c8a3e66716c1f0cd2